### PR TITLE
feat: Implement server-side filtering for incidents

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -34,13 +34,19 @@ async def create_new_incident(
 async def read_all_incidents(
     skip: int = Query(0, ge=0, description="Number of records to skip for pagination"),
     limit: int = Query(100, ge=1, le=200, description="Maximum number of records to return"),
+    status: Optional[str] = Query(None, description="Filter by incident status (e.g., Ouvert, Résolu)"),
+    criticite: Optional[str] = Query(None, description="Filter by incident criticité (e.g., Critique, Moyen)"),
     current_user: Annotated[models.User, Depends(get_current_active_user)]
 ):
     """
-    Retrieve all incidents with pagination. Requires authentication.
+    Retrieve all incidents with pagination and optional filtering by status and criticité. Requires authentication.
     """
-    incidents_records = await crud_incidents.get_incidents(skip=skip, limit=limit)
-    total_incidents = await crud_incidents.count_incidents()
+    incidents_records = await crud_incidents.get_incidents(
+        skip=skip, limit=limit, status=status, criticite=criticite
+    )
+    total_incidents = await crud_incidents.count_incidents(
+        status=status, criticite=criticite
+    )
 
     # Convert each record (which are SQLAlchemy RowProxy objects from 'databases')
     # to schemas.IncidentRead if needed, though Pydantic's from_attributes should handle it.

--- a/backend/crud_incidents.py
+++ b/backend/crud_incidents.py
@@ -46,11 +46,47 @@ async def get_incidents(skip: int = 0, limit: int = 100) -> List[models.Incident
     results = await database.fetch_all(query)
     return results
 
-async def count_incidents() -> int:
+async def get_incidents(
+    skip: int = 0,
+    limit: int = 100,
+    status: Optional[str] = None,
+    criticite: Optional[str] = None
+) -> List[models.Incident]:
     """
-    Counts the total number of incidents.
+    Retrieves a list of incidents with pagination and optional filtering.
+    """
+    query = select(models.Incident.__table__)
+
+    # Apply filters dynamically
+    if status:
+        # Assuming status in the DB matches StatutIncident enum values directly
+        # Or convert/validate status string against models.StatutIncident if needed
+        query = query.where(models.Incident.__table__.c.statut == status)
+    if criticite:
+        # Assuming criticite in the DB matches CriticiteLevel enum values directly
+        query = query.where(models.Incident.__table__.c.criticite == criticite)
+
+    query = query.offset(skip).limit(limit).order_by(models.Incident.__table__.c.id.desc())
+
+    results = await database.fetch_all(query)
+    return results
+
+
+async def count_incidents(
+    status: Optional[str] = None,
+    criticite: Optional[str] = None
+) -> int:
+    """
+    Counts the total number of incidents, optionally applying filters.
     """
     query = select(func.count()).select_from(models.Incident.__table__)
+
+    # Apply filters dynamically, same as in get_incidents
+    if status:
+        query = query.where(models.Incident.__table__.c.statut == status)
+    if criticite:
+        query = query.where(models.Incident.__table__.c.criticite == criticite)
+
     count = await database.fetch_val(query)
     return count if count is not None else 0
 


### PR DESCRIPTION
- Updated `crud_incidents.get_incidents` to accept optional `status` and `criticite` parameters and dynamically build the query with WHERE clauses.
- Updated `crud_incidents.count_incidents` to also accept and apply these filter parameters to ensure the total count reflects the filtered dataset.
- Modified the `GET /api/v1/incidents/` endpoint (`read_all_incidents` function in `backend/api/endpoints.py`) to accept `status` and `criticite` as optional query parameters and pass them to the CRUD functions.