### PR TITLE
feat: Add Threat Intelligence (IoC) management

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -32,12 +32,12 @@ async def create_new_incident(
 
 @router.get("/incidents/", response_model=schemas.IncidentList)
 async def read_all_incidents(
+    current_user: Annotated[models.User, Depends(get_current_active_user)],
     skip: int = Query(0, ge=0, description="Number of records to skip for pagination"),
     limit: int = Query(100, ge=1, le=200, description="Maximum number of records to return"),
     status: Optional[str] = Query(None, description="Filter by incident status (e.g., Ouvert, Résolu)"),
     criticite: Optional[str] = Query(None, description="Filter by incident criticité (e.g., Critique, Moyen)"),
-    sort_by: Optional[str] = Query(None, description="Sort by field and direction. Format: field_name:direction (e.g., timestamp:desc or title:asc)"),
-    current_user: Annotated[models.User, Depends(get_current_active_user)]
+    sort_by: Optional[str] = Query(None, description="Sort by field and direction. Format: field_name:direction (e.g., timestamp:desc or title:asc)")
 ):
     """
     Retrieve all incidents with pagination, optional filtering by status and criticité, and sorting. Requires authentication.

--- a/backend/api/iocs.py
+++ b/backend/api/iocs.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, HTTPException, Depends, Query
+from typing import List, Optional, Annotated
+
+from .. import crud_iocs, schemas, models
+from .auth import get_current_active_user
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.IoCRead, status_code=201)
+async def create_new_ioc(
+    ioc: schemas.IoCCreate,
+    current_user: Annotated[models.User, Depends(get_current_active_user)]
+):
+    """
+    Create a new Indicator of Compromise (IoC). Requires authentication.
+    """
+    created_ioc = await crud_iocs.create_ioc(ioc_data=ioc)
+    return created_ioc
+
+@router.get("/", response_model=schemas.IoCList)
+async def read_all_iocs(
+    current_user: Annotated[models.User, Depends(get_current_active_user)],
+    skip: int = Query(0, ge=0, description="Number of records to skip for pagination"),
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of records to return"),
+    ioc_type: Optional[str] = Query(None, description="Filter by IoC type (e.g., ip_address, domain_name)")
+):
+    """
+    Retrieve all IoCs with pagination and optional filtering by type. Requires authentication.
+    """
+    ioc_records = await crud_iocs.get_iocs(skip=skip, limit=limit, ioc_type=ioc_type)
+    total_iocs = await crud_iocs.count_iocs(ioc_type=ioc_type)
+    return schemas.IoCList(items=ioc_records, total=total_iocs)
+
+@router.get("/{ioc_id}", response_model=schemas.IoCRead)
+async def read_single_ioc(
+    ioc_id: int,
+    current_user: Annotated[models.User, Depends(get_current_active_user)]
+):
+    """
+    Retrieve a single IoC by its ID. Requires authentication.
+    """
+    db_ioc = await crud_iocs.get_ioc(ioc_id=ioc_id)
+    if db_ioc is None:
+        raise HTTPException(status_code=404, detail="IoC not found")
+    return db_ioc
+
+@router.put("/{ioc_id}", response_model=schemas.IoCRead)
+async def update_existing_ioc(
+    ioc_id: int,
+    ioc_update: schemas.IoCUpdate,
+    current_user: Annotated[models.User, Depends(get_current_active_user)]
+):
+    """
+    Update an existing IoC. Requires authentication.
+    """
+    updated_ioc = await crud_iocs.update_ioc(ioc_id=ioc_id, ioc_data=ioc_update)
+    if updated_ioc is None:
+        raise HTTPException(status_code=404, detail="IoC not found for update")
+    return updated_ioc
+
+@router.delete("/{ioc_id}", status_code=204)
+async def delete_existing_ioc(
+    ioc_id: int,
+    current_user: Annotated[models.User, Depends(get_current_active_user)]
+):
+    """
+    Delete an IoC by its ID. Requires authentication.
+    """
+    success = await crud_iocs.delete_ioc(ioc_id=ioc_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="IoC not found or could not be deleted")
+    return

--- a/backend/api/systems.py
+++ b/backend/api/systems.py
@@ -25,9 +25,9 @@ async def create_new_system(
 
 @router.get("/", response_model=List[schemas.SystemRead])
 async def read_all_systems(
+    current_user: Annotated[models.User, Depends(get_current_active_user)],
     skip: int = Query(0, ge=0),
-    limit: int = Query(20, ge=1, le=100), # Default 20, max 100
-    current_user: Annotated[models.User, Depends(get_current_active_user)]
+    limit: int = Query(20, ge=1, le=100) # Default 20, max 100
 ):
     """
     Retrieve all systems with pagination. Requires authentication.

--- a/backend/crud_iocs.py
+++ b/backend/crud_iocs.py
@@ -1,0 +1,87 @@
+from sqlalchemy import select, update, delete, func
+from typing import List, Optional
+import datetime
+
+from . import models
+from . import schemas
+from .database import database
+
+async def create_ioc(ioc_data: schemas.IoCCreate) -> models.IndicatorOfCompromise:
+    """
+    Creates a new IoC in the database.
+    """
+    values = ioc_data.model_dump()
+    now = datetime.datetime.utcnow()
+    values['first_seen'] = now
+    values['last_seen'] = now
+    query = models.IndicatorOfCompromise.__table__.insert().values(**values)
+    last_record_id = await database.execute(query)
+    return await get_ioc(ioc_id=last_record_id)
+
+async def get_ioc(ioc_id: int) -> Optional[models.IndicatorOfCompromise]:
+    """
+    Retrieves a single IoC by its ID.
+    """
+    query = select(models.IndicatorOfCompromise.__table__).where(models.IndicatorOfCompromise.__table__.c.id == ioc_id)
+    result = await database.fetch_one(query)
+    return result if result else None
+
+async def get_iocs(
+    skip: int = 0,
+    limit: int = 100,
+    ioc_type: Optional[str] = None
+) -> List[models.IndicatorOfCompromise]:
+    """
+    Retrieves a list of IoCs with pagination and optional filtering.
+    """
+    query = select(models.IndicatorOfCompromise.__table__)
+
+    if ioc_type:
+        query = query.where(models.IndicatorOfCompromise.__table__.c.type == ioc_type)
+
+    query = query.order_by(models.IndicatorOfCompromise.__table__.c.last_seen.desc())
+    query = query.offset(skip).limit(limit)
+
+    results = await database.fetch_all(query)
+    return results
+
+async def count_iocs(ioc_type: Optional[str] = None) -> int:
+    """
+    Counts the total number of IoCs, optionally applying filters.
+    """
+    query = select(func.count()).select_from(models.IndicatorOfCompromise.__table__)
+
+    if ioc_type:
+        query = query.where(models.IndicatorOfCompromise.__table__.c.type == ioc_type)
+
+    count = await database.fetch_val(query)
+    return count if count is not None else 0
+
+async def update_ioc(ioc_id: int, ioc_data: schemas.IoCUpdate) -> Optional[models.IndicatorOfCompromise]:
+    """
+    Updates an existing IoC.
+    """
+    update_data = ioc_data.model_dump(exclude_unset=True)
+
+    if not update_data:
+        return await get_ioc(ioc_id)
+
+    query = (
+        update(models.IndicatorOfCompromise.__table__)
+        .where(models.IndicatorOfCompromise.__table__.c.id == ioc_id)
+        .values(**update_data)
+    )
+    await database.execute(query)
+    return await get_ioc(ioc_id)
+
+async def delete_ioc(ioc_id: int) -> bool:
+    """
+    Deletes an IoC by its ID.
+    """
+    ioc = await get_ioc(ioc_id)
+    if not ioc:
+        return False
+
+    query = delete(models.IndicatorOfCompromise.__table__).where(models.IndicatorOfCompromise.__table__.c.id == ioc_id)
+    await database.execute(query)
+    return True

--- a/backend/crud_users.py
+++ b/backend/crud_users.py
@@ -19,6 +19,9 @@ async def create_user(user_data: schemas.UserCreate) -> models.User:
     user_db_values = user_data.model_dump()
     del user_db_values['password'] # Remove plain password
     user_db_values['hashed_password'] = hashed_password
+    # Explicitly set default values to ensure they are present for the INSERT statement
+    user_db_values.setdefault('is_active', True)
+    user_db_values.setdefault('is_superuser', False)
 
     query = models.User.__table__.insert().values(**user_db_values)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from .api.endpoints import router as incidents_api_router
 from .api.auth import router as auth_api_router
 from .api.dashboard import router as dashboard_api_router
 from .api.systems import router as systems_api_router # Import the new systems router
+from .api.iocs import router as iocs_api_router
 
 
 @asynccontextmanager
@@ -47,6 +48,7 @@ app.include_router(incidents_api_router, prefix="/api/v1/incidents", tags=["Inci
 app.include_router(auth_api_router, prefix="/api/v1/auth", tags=["Authentication"])
 app.include_router(dashboard_api_router, prefix="/api/v1/dashboard", tags=["Dashboard"])
 app.include_router(systems_api_router, prefix="/api/v1/systems", tags=["Systems"])
+app.include_router(iocs_api_router, prefix="/api/v1/iocs", tags=["IoCs"])
 
 
 @app.get("/test-db")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Enum as SAEnum
+from sqlalchemy import Column, Integer, String, DateTime, Enum as SAEnum, Boolean, Float
 from sqlalchemy.ext.declarative import declarative_base
 from .database import metadata # Using the metadata instance from database.py
 import datetime
@@ -68,6 +68,29 @@ class System(Base):
 
     def __repr__(self):
         return f"<System(id={self.id}, name='{self.name}', status='{self.status}')>"
+
+
+class IoCType(str, enum.Enum):
+    IP_ADDRESS = "ip_address"
+    DOMAIN_NAME = "domain_name"
+    FILE_HASH_MD5 = "md5"
+    FILE_HASH_SHA1 = "sha1"
+    FILE_HASH_SHA256 = "sha256"
+    URL = "url"
+
+class IndicatorOfCompromise(Base):
+    __tablename__ = "iocs"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    value = Column(String, index=True, nullable=False, unique=True) # The IoC value itself
+    type = Column(SAEnum(IoCType), nullable=False)
+    source = Column(String, nullable=True) # E.g., MISP, AlienVault OTX, Manual
+    first_seen = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+    last_seen = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
+    malicious_confidence = Column(Integer, nullable=True) # Confidence level (e.g., 0-100)
+
+    def __repr__(self):
+        return f"<IndicatorOfCompromise(id={self.id}, type='{self.type}', value='{self.value}')>"
 
 
 # You can add other models here as the application grows.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,4 +23,6 @@ uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1
 passlib[bcrypt]>=1.7.4 # Added for password hashing
+bcrypt==3.2.0 # Pinned for compatibility with passlib
 python-jose[cryptography]>=3.3.0 # Added for JWT handling
+python-multipart==0.0.20 # Added for form data parsing

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -127,3 +127,33 @@ class SystemRead(SystemBase):
     last_checked_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# --- IoC Schemas ---
+from .models import IoCType
+
+class IoCBase(BaseModel):
+    value: str
+    type: IoCType
+    source: Optional[str] = None
+    malicious_confidence: Optional[int] = None
+
+class IoCCreate(IoCBase):
+    pass
+
+class IoCUpdate(BaseModel):
+    value: Optional[str] = None
+    type: Optional[IoCType] = None
+    source: Optional[str] = None
+    malicious_confidence: Optional[int] = None
+
+class IoCRead(IoCBase):
+    id: int
+    first_seen: datetime
+    last_seen: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+class IoCList(BaseModel):
+    items: List[IoCRead]
+    total: int

--- a/index.html
+++ b/index.html
@@ -276,34 +276,34 @@
             <!-- Page Threat Intelligence -->
             <div id="threats" class="page">
                 <div class="page-header">
-                    <h1>Threat Intelligence</h1>
+                    <h1>Indicateurs de Compromission (IoCs)</h1>
+                    <div class="header-actions">
+                        <button class="btn btn--primary btn--sm" id="new-ioc-btn">
+                            <i data-lucide="plus"></i>
+                            Nouvel IoC
+                        </button>
+                    </div>
                 </div>
 
-                <div class="threats-grid">
-                    <div class="card">
-                        <div class="card__header">
-                            <h3>Types de Menaces</h3>
-                        </div>
-                        <div class="card__body">
-                            <canvas id="threatTypesChart"></canvas>
-                        </div>
-                    </div>
-
-                    <div class="card">
-                        <div class="card__header">
-                            <h3>Flux de Menaces</h3>
-                        </div>
-                        <div class="card__body">
-                            <div id="threat-feed"></div>
-                        </div>
-                    </div>
-
-                    <div class="card">
-                        <div class="card__header">
-                            <h3>Indicateurs de Compromission</h3>
-                        </div>
-                        <div class="card__body">
-                            <div id="ioc-list"></div>
+                <div class="card">
+                    <div class="card__body">
+                        <div class="iocs-table">
+                            <div class="table-header">
+                                <div class="col-id" style="flex-basis: 5%;">ID</div>
+                                <div class="col-ioc-value" style="flex-basis: 40%;">Valeur</div>
+                                <div class="col-ioc-type" style="flex-basis: 15%;">Type</div>
+                                <div class="col-ioc-source" style="flex-basis: 15%;">Source</div>
+                                <div class="col-date" style="flex-basis: 15%;">Dernière vue</div>
+                                <div class="col-actions" style="flex-basis: 10%;">Actions</div>
+                            </div>
+                            <div id="iocs-list">
+                                <!-- IoC rows will be inserted here by JavaScript -->
+                            </div>
+                            <div id="iocs-pagination-controls" class="pagination-controls">
+                                <button id="iocs-prev-page-btn" class="btn btn--secondary btn--sm" disabled>&laquo; Précédent</button>
+                                <span id="iocs-page-info"></span>
+                                <button id="iocs-next-page-btn" class="btn btn--secondary btn--sm" disabled>Suivant &raquo;</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -537,6 +537,39 @@
                     <div class="modal-actions">
                         <button type="button" class="btn btn--secondary" id="edit-modal-cancel-btn">Annuler</button>
                         <button type="submit" class="btn btn--primary">Enregistrer les Modifications</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal for New IoC -->
+    <div id="new-ioc-modal" class="modal" style="display: none;">
+        <div class="modal-content card">
+            <div class="modal-header card__header">
+                <h3>Créer un Nouvel Indicateur de Compromission (IoC)</h3>
+                <button class="modal-close-btn" id="ioc-modal-close-btn">&times;</button>
+            </div>
+            <div class="modal-body card__body">
+                <form id="new-ioc-form">
+                    <div class="form-group">
+                        <label for="ioc-value" class="form-label">Valeur de l'indicateur</label>
+                        <input type="text" id="ioc-value" name="value" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="ioc-type" class="form-label">Type</label>
+                        <select id="ioc-type" name="type" class="form-control" required>
+                            <!-- Options will be populated by JavaScript -->
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="ioc-source" class="form-label">Source (ex: MISP, Manual)</label>
+                        <input type="text" id="ioc-source" name="source" class="form-control">
+                    </div>
+                    <div id="ioc-modal-error-message" class="error-message" style="display: none; margin-bottom: 16px;"></div>
+                    <div class="modal-actions">
+                        <button type="button" class="btn btn--secondary" id="ioc-modal-cancel-btn">Annuler</button>
+                        <button type="submit" class="btn btn--primary">Enregistrer</button>
                     </div>
                 </form>
             </div>

--- a/uvicorn.log
+++ b/uvicorn.log
@@ -1,0 +1,10 @@
+INFO:     Started server process [14611]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+ERROR:    [Errno 98] error while attempting to bind on address ('0.0.0.0', 8000): address already in use
+INFO:     Waiting for application shutdown.
+INFO:     Application shutdown complete.
+Attempting to connect to the database...
+Database connection established and app.state.db_connected=True.
+Attempting to disconnect from the database...
+Database connection closed and app.state.db_connected=False.


### PR DESCRIPTION
This commit introduces a new feature for managing Indicators of Compromise (IoCs) as the first step towards building a Threat Intelligence capability.

Backend Changes:
- Adds a new `iocs` table to the database (`IndicatorOfCompromise` model).
- Adds corresponding Pydantic schemas for API data validation.
- Implements a full CRUD API at `/api/v1/iocs/` for creating, reading, and deleting IoCs.
- Ensures all new endpoints are protected by authentication.

Frontend Changes:
- Replaces the mock "Threat Intelligence" page with a dynamic page for IoC management.
- Adds a table to list IoCs with pagination.
- Implements a modal form to create new IoCs.
- Adds functionality to delete IoCs from the list.

Fixes & Chores:
- Resolves several bugs discovered during testing, including a `passlib`/`bcrypt` version incompatibility, incorrect API routing, and missing default values in database models.
- Pins the `bcrypt` version to `3.2.0` in `requirements.txt` for stability.
- Adds `python-multipart` as an explicit dependency.